### PR TITLE
Rename ParticipantTypeAgent to ParticipantTypeHumanAgent

### DIFF
--- a/message.go
+++ b/message.go
@@ -16,9 +16,9 @@ const (
 	// customer/end-user.
 	ParticipantTypeCustomer ParticipantType = "Customer"
 
-	// ParticipantTypeAgent indicates that the message was sent by a human support
+	// ParticipantTypeHumanAgent indicates that the message was sent by a human support
 	// agent.
-	ParticipantTypeAgent ParticipantType = "Agent"
+	ParticipantTypeHumanAgent ParticipantType = "Agent"
 
 	// ParticipantTypeBot indicates that the message was sent by an automation/bot
 	// other than the Gradient Labs AI agent.


### PR DESCRIPTION
> Also :pinching_hand: tiny nit in the API - the bot is referred to as the agent throughout the docs, but ParticipantTypeAgent is a human. Not a big deal and realise it's not wrong, but I was briefly confused.
Could maybe disambiguate with e.g. ParticipantTypeHumanAgent or similar :relaxed: