### PR TITLE
Update go-client to include assignment apis

### DIFF
--- a/conversation.go
+++ b/conversation.go
@@ -1,10 +1,6 @@
 package client
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
-	"net/http"
 	"time"
 )
 
@@ -48,29 +44,6 @@ const (
 	StatusFailed Status = "failed"
 )
 
-// StartConversationParams are the parameters to Client.StartConversation.
-type StartConversationParams struct {
-	// ID uniquely identifies the conversation.
-	//
-	// Can be anything consisting of letters, numbers, or any of the following
-	// characters: _ - + =.
-	//
-	// Tip: use something meaningful to your business (e.g. a ticket number).
-	ID string `json:"id"`
-
-	// CustomerID uniquely identifies the customer. Used to build historical
-	// context of conversations the agent has had with this customer.
-	CustomerID string `json:"customer_id"`
-
-	// Channel represents the way a customer is getting in touch. It will be used
-	// to determine how the agent formats responses, etc.
-	Channel Channel `json:"channel"`
-
-	// Metadata is arbitrary metadata that will be attached to the conversation.
-	// It will be passed along with webhooks so can be used as action parameters.
-	Metadata any `json:"metadata"`
-}
-
 // Conversation represents a series of messages between a customer, human agent,
 // and the AI Agent.
 type Conversation struct {
@@ -102,39 +75,4 @@ type Conversation struct {
 
 	// Status describes the current state of the conversation.
 	Status Status `json:"status"`
-}
-
-// StartConversation begins a conversation with the agent.
-func (c *Client) StartConversation(ctx context.Context, p StartConversationParams) (*Conversation, error) {
-	rsp, err := c.makeRequest(ctx, http.MethodPost, "conversations", p)
-	if err != nil {
-		return nil, err
-	}
-	defer rsp.Body.Close()
-
-	if rsp.StatusCode < 200 || rsp.StatusCode > 299 {
-		return nil, newResponseError(rsp)
-	}
-
-	var conv Conversation
-	if err := json.NewDecoder(rsp.Body).Decode(&conv); err != nil {
-		return nil, err
-	}
-	return &conv, nil
-}
-
-// CancelConversation cancels a conversation to abruptly stop the agent
-// responding (e.g. because a human agent has taken over).
-func (c *Client) CancelConversation(ctx context.Context, conversationID string) error {
-	rsp, err := c.makeRequest(ctx, http.MethodPut, fmt.Sprintf("conversations/%s/cancel", conversationID), nil)
-	if err != nil {
-		return err
-	}
-	defer rsp.Body.Close()
-
-	if rsp.StatusCode < 200 || rsp.StatusCode > 299 {
-		return newResponseError(rsp)
-	}
-
-	return nil
 }

--- a/conversation_assign.go
+++ b/conversation_assign.go
@@ -25,8 +25,8 @@ func (c *Client) AssignConversation(ctx context.Context, conversationID string, 
 	}
 	defer rsp.Body.Close()
 
-	if rsp.StatusCode < 200 || rsp.StatusCode > 299 {
-		return newResponseError(rsp)
+	if err := responseError(rsp); err != nil {
+		return err
 	}
 	return nil
 }

--- a/conversation_assign.go
+++ b/conversation_assign.go
@@ -19,7 +19,7 @@ type AssignmentParams struct {
 
 // AssignConversation assigns a conversation to a participant.
 func (c *Client) AssignConversation(ctx context.Context, conversationID string, p *AssignmentParams) error {
-	rsp, err := c.makeRequest(ctx, http.MethodPost, fmt.Sprintf("/conversations/%s/end", conversationID), p)
+	rsp, err := c.makeRequest(ctx, http.MethodPut, fmt.Sprintf("/conversations/%s/assignee", conversationID), p)
 	if err != nil {
 		return err
 	}

--- a/conversation_assign.go
+++ b/conversation_assign.go
@@ -1,0 +1,32 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+type AssignmentParams struct {
+	// AssigneeID optionally identifies the specific user that the conversation
+	// is being assigned to.
+	AssigneeID string `json:"assignee_id,omitempty"`
+
+	// AssigneeType identifies the type of participant that this conversation is
+	// being assigned to. Set this to ParticipantTypeAIAgent to assign the conversation
+	// to the Gradient Labs AI agent.
+	AssigneeType ParticipantType `json:"assignee_type"`
+}
+
+// AssignConversation assigns a conversation to a participant.
+func (c *Client) AssignConversation(ctx context.Context, conversationID string, p *AssignmentParams) error {
+	rsp, err := c.makeRequest(ctx, http.MethodPost, fmt.Sprintf("/conversations/%s/end", conversationID), p)
+	if err != nil {
+		return err
+	}
+	defer rsp.Body.Close()
+
+	if rsp.StatusCode < 200 || rsp.StatusCode > 299 {
+		return newResponseError(rsp)
+	}
+	return nil
+}

--- a/conversation_end.go
+++ b/conversation_end.go
@@ -14,8 +14,8 @@ func (c *Client) EndConversation(ctx context.Context, conversationID string) err
 	}
 	defer rsp.Body.Close()
 
-	if rsp.StatusCode < 200 || rsp.StatusCode > 299 {
-		return newResponseError(rsp)
+	if err := responseError(rsp); err != nil {
+		return err
 	}
 	return nil
 }

--- a/conversation_end.go
+++ b/conversation_end.go
@@ -1,0 +1,21 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// EndConversation ends a conversation.
+func (c *Client) EndConversation(ctx context.Context, conversationID string) error {
+	rsp, err := c.makeRequest(ctx, http.MethodPost, fmt.Sprintf("/conversations/%s/end", conversationID), nil)
+	if err != nil {
+		return err
+	}
+	defer rsp.Body.Close()
+
+	if rsp.StatusCode < 200 || rsp.StatusCode > 299 {
+		return newResponseError(rsp)
+	}
+	return nil
+}

--- a/conversation_read.go
+++ b/conversation_read.go
@@ -1,0 +1,27 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// ReadConversation returns a conversation.
+func (c *Client) ReadConversation(ctx context.Context, conversationID string) (*Conversation, error) {
+	rsp, err := c.makeRequest(ctx, http.MethodPost, fmt.Sprintf("/conversations/%s", conversationID), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer rsp.Body.Close()
+
+	if rsp.StatusCode < 200 || rsp.StatusCode > 299 {
+		return nil, newResponseError(rsp)
+	}
+
+	var conv Conversation
+	if err := json.NewDecoder(rsp.Body).Decode(&conv); err != nil {
+		return nil, err
+	}
+	return &conv, nil
+}

--- a/conversation_read.go
+++ b/conversation_read.go
@@ -9,7 +9,7 @@ import (
 
 // ReadConversation returns a conversation.
 func (c *Client) ReadConversation(ctx context.Context, conversationID string) (*Conversation, error) {
-	rsp, err := c.makeRequest(ctx, http.MethodPost, fmt.Sprintf("/conversations/%s", conversationID), nil)
+	rsp, err := c.makeRequest(ctx, http.MethodGet, fmt.Sprintf("/conversations/%s", conversationID), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/conversation_read.go
+++ b/conversation_read.go
@@ -15,8 +15,8 @@ func (c *Client) ReadConversation(ctx context.Context, conversationID string) (*
 	}
 	defer rsp.Body.Close()
 
-	if rsp.StatusCode < 200 || rsp.StatusCode > 299 {
-		return nil, newResponseError(rsp)
+	if err := responseError(rsp); err != nil {
+		return nil, err
 	}
 
 	var conv Conversation

--- a/conversation_start.go
+++ b/conversation_start.go
@@ -1,0 +1,57 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+// StartConversationParams are the parameters to Client.StartConversation.
+type StartConversationParams struct {
+	// ID uniquely identifies the conversation.
+	//
+	// Can be anything consisting of letters, numbers, or any of the following
+	// characters: _ - + =.
+	//
+	// Tip: use something meaningful to your business (e.g. a ticket number).
+	ID string `json:"id"`
+
+	// CustomerID uniquely identifies the customer. Used to build historical
+	// context of conversations the agent has had with this customer.
+	CustomerID string `json:"customer_id"`
+
+	// AssigneeID optionally identifies who the conversation is assigned to.
+	AssigneeID string `json:"assignee_id,omitempty"`
+
+	// AssigneeType optionally identifies which type of participant is currently
+	// assigned to respond. Set this to ParticipantTypeAIAgent to assign the conversation
+	// to the Gradient Labs AI when starting it.
+	AssigneeType ParticipantType `json:"assignee_type,omitempty"`
+
+	// Channel represents the way a customer is getting in touch. It will be used
+	// to determine how the agent formats responses, etc.
+	Channel Channel `json:"channel"`
+
+	// Metadata is arbitrary metadata that will be attached to the conversation.
+	// It will be passed along with webhooks so can be used as action parameters.
+	Metadata any `json:"metadata"`
+}
+
+// StartConversation begins a conversation.
+func (c *Client) StartConversation(ctx context.Context, p StartConversationParams) (*Conversation, error) {
+	rsp, err := c.makeRequest(ctx, http.MethodPost, "conversations", p)
+	if err != nil {
+		return nil, err
+	}
+	defer rsp.Body.Close()
+
+	if rsp.StatusCode < 200 || rsp.StatusCode > 299 {
+		return nil, newResponseError(rsp)
+	}
+
+	var conv Conversation
+	if err := json.NewDecoder(rsp.Body).Decode(&conv); err != nil {
+		return nil, err
+	}
+	return &conv, nil
+}

--- a/conversation_start.go
+++ b/conversation_start.go
@@ -45,8 +45,8 @@ func (c *Client) StartConversation(ctx context.Context, p StartConversationParam
 	}
 	defer rsp.Body.Close()
 
-	if rsp.StatusCode < 200 || rsp.StatusCode > 299 {
-		return nil, newResponseError(rsp)
+	if err := responseError(rsp); err != nil {
+		return nil, err
 	}
 
 	var conv Conversation

--- a/example/main.go
+++ b/example/main.go
@@ -62,7 +62,15 @@ func run(client *glabs.Client) error {
 		return err
 	}
 	fmt.Printf("Message: %#v\n", msg)
-	if err := client.CancelConversation(ctx, conv.ID); err != nil {
+
+	err = client.AssignConversation(ctx, conv.ID, &glabs.AssignmentParams{
+		AssigneeType: glabs.ParticipantTypeAIAgent,
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := client.EndConversation(ctx, conv.ID); err != nil {
 		return err
 	}
 

--- a/message.go
+++ b/message.go
@@ -8,21 +8,22 @@ import (
 	"time"
 )
 
-// ParticipantType identifies the type of participant who sent a message.
+// ParticipantType identifies the type of participant who sent a message or
+// is assigned to a conversation.
 type ParticipantType string
 
 const (
-	// ParticipantTypeCustomer indicates that the message was sent by a
-	// customer/end-user.
+	// ParticipantTypeCustomer is a  customer/end-user.
 	ParticipantTypeCustomer ParticipantType = "Customer"
 
-	// ParticipantTypeHumanAgent indicates that the message was sent by a human support
-	// agent.
+	// ParticipantTypeHumanAgent is a human support agent.
 	ParticipantTypeHumanAgent ParticipantType = "Agent"
 
-	// ParticipantTypeBot indicates that the message was sent by an automation/bot
-	// other than the Gradient Labs AI agent.
+	// ParticipantTypeBot is an automation/bot other than the Gradient Labs AI agent.
 	ParticipantTypeBot ParticipantType = "Bot"
+
+	// ParticipantTypeAIAgent is the Gradient Labs AI agent.
+	ParticipantTypeAIAgent ParticipantType = "AI Agent"
 )
 
 // AttachmentType identifies the type of file that has been attached to a

--- a/message.go
+++ b/message.go
@@ -99,8 +99,8 @@ func (c *Client) AddMessage(ctx context.Context, conversationID string, p AddMes
 	}
 	defer rsp.Body.Close()
 
-	if rsp.StatusCode < 200 || rsp.StatusCode > 299 {
-		return nil, newResponseError(rsp)
+	if err := responseError(rsp); err != nil {
+		return nil, err
 	}
 
 	var msg Message

--- a/message.go
+++ b/message.go
@@ -8,24 +8,6 @@ import (
 	"time"
 )
 
-// ParticipantType identifies the type of participant who sent a message or
-// is assigned to a conversation.
-type ParticipantType string
-
-const (
-	// ParticipantTypeCustomer is a  customer/end-user.
-	ParticipantTypeCustomer ParticipantType = "Customer"
-
-	// ParticipantTypeHumanAgent is a human support agent.
-	ParticipantTypeHumanAgent ParticipantType = "Agent"
-
-	// ParticipantTypeBot is an automation/bot other than the Gradient Labs AI agent.
-	ParticipantTypeBot ParticipantType = "Bot"
-
-	// ParticipantTypeAIAgent is the Gradient Labs AI agent.
-	ParticipantTypeAIAgent ParticipantType = "AI Agent"
-)
-
 // AttachmentType identifies the type of file that has been attached to a
 // message. Currently, our AI agent does not support processing attachments,
 // and will hand the conversation off to a human agent if it encounters one.
@@ -66,6 +48,7 @@ type AddMessageParams struct {
 	ParticipantID string `json:"participant_id"`
 
 	// ParticipantType identifies the type of participant who sent this message.
+	// This cannot be set to ParticipantTypeAI.
 	ParticipantType ParticipantType `json:"participant_type"`
 
 	// Created is the time at which the message was sent.

--- a/participant.go
+++ b/participant.go
@@ -1,0 +1,19 @@
+package client
+
+// ParticipantType identifies the type of participant who sent a message or
+// is assigned to a conversation.
+type ParticipantType string
+
+const (
+	// ParticipantTypeCustomer is a  customer/end-user.
+	ParticipantTypeCustomer ParticipantType = "Customer"
+
+	// ParticipantTypeHumanAgent is a human support agent.
+	ParticipantTypeHumanAgent ParticipantType = "Agent"
+
+	// ParticipantTypeBot is an automation/bot other than the Gradient Labs AI agent.
+	ParticipantTypeBot ParticipantType = "Bot"
+
+	// ParticipantTypeAIAgent is the Gradient Labs AI agent.
+	ParticipantTypeAIAgent ParticipantType = "AI Agent"
+)


### PR DESCRIPTION
The updated way to manage a conversation:

- `client.StartConversation()` to start and (optionally) assign it
- `client.AddMessage()` to add messages
- `client.AssignConversation()` to assign it 
- `client.EndConversation()` when it is finished