### PR TITLE
Fix comment

### DIFF
--- a/conversation_event.go
+++ b/conversation_event.go
@@ -32,7 +32,7 @@ const (
 )
 
 type EventParams struct {
-	// Type identifies the type of event (start-typing, stop-typing, join, leave).
+	// Type identifies the type of event (see: ConversationEventType).
 	Type ConversationEventType `json:"type"`
 
 	// ParticipantID identifies the message sender.


### PR DESCRIPTION
This comment is out of date with respect to the types of events we support