### PR TITLE
Fix RateConversation to accept *RatingParams instead of *AssignmentParams

### DIFF
--- a/conversation_rate.go
+++ b/conversation_rate.go
@@ -32,7 +32,7 @@ type RatingParams struct {
 }
 
 // RateConversation submits a customer (CSAT) rating for a conversation.
-func (c *Client) RateConversation(ctx context.Context, conversationID string, p *AssignmentParams) error {
+func (c *Client) RateConversation(ctx context.Context, conversationID string, p *RatingParams) error {
 	rsp, err := c.makeRequest(ctx, http.MethodPut, fmt.Sprintf("conversations/%s/rate", conversationID), p)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

- `RateConversation` was incorrectly typed to accept `*AssignmentParams`, which is used for conversation assignment, not CSAT ratings.
- `RatingParams` is already defined in `conversation_rate.go` with the correct fields (`SurveyType`, `Value`, `MaxValue`, `MinValue`, `Comments`, `Timestamp`).
- This change corrects the method signature to use `*RatingParams` as intended.

## Test plan

- [ ] Confirm the method signature in `conversation_rate.go` now references `*RatingParams`
- [ ] Verify the package still builds (`go build ./...`)
- [ ] Confirm no other callers pass `*AssignmentParams` to this method (there should be none, as the old type was wrong)

🤖 Generated with [Claude Code](https://claude.com/claude-code)