### PR TITLE
Add ChannelVoice constant

### DIFF
--- a/conversation.go
+++ b/conversation.go
@@ -18,6 +18,9 @@ const (
 
 	// ChannelEmail indicates the customer is getting in touch via an email.
 	ChannelEmail Channel = "email"
+
+	// ChannelVoice indicates the customer is getting in touch via a voice call.
+	ChannelVoice Channel = "voice"
 )
 
 // Status describes the current state of the conversation.


### PR DESCRIPTION
## Summary

- The backend accepts three channels: `web`, `email`, and `voice`
- The client was missing the `ChannelVoice` constant for the `voice` channel
- Added `ChannelVoice Channel = "voice"` to the `Channel` constants block in `conversation.go`

## Test plan

- [ ] Confirm `ChannelVoice` is exported and has value `"voice"`
- [ ] Confirm existing constants (`ChannelWeb`, `ChannelChat`, `ChannelEmail`) are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)