### PR TITLE
Add ExcludedTargets field to TrafficGroup struct

### DIFF
--- a/traffic_group.go
+++ b/traffic_group.go
@@ -5,6 +5,8 @@ type TrafficGroup struct {
 	ID      string               `json:"id"`
 	Name    string               `json:"name"`
 	Targets []TrafficGroupTarget `json:"targets"`
+	// ExcludedTargets lists the procedures explicitly excluded from this traffic group.
+	ExcludedTargets []TrafficGroupTarget `json:"excluded_targets"`
 }
 
 // TrafficGroupTarget represents a target within a traffic group.


### PR DESCRIPTION
## Summary

- The backend `TrafficGroupResponse` returns both `targets` and `excluded_targets` arrays
- The client `TrafficGroup` struct only had a `Targets` field, so `excluded_targets` from the API response was silently dropped during JSON deserialization
- Adds `ExcludedTargets []TrafficGroupTarget` with the correct `json:"excluded_targets"` tag after the existing `Targets` field

## Test plan

- [ ] Verify that a `TrafficGroup` response containing `excluded_targets` now correctly populates `ExcludedTargets` in the Go struct

🤖 Generated with [Claude Code](https://claude.com/claude-code)