### PR TITLE
Add Subject field to AddMessageParams and Message

### DIFF
--- a/conversation_add_message.go
+++ b/conversation_add_message.go
@@ -66,6 +66,9 @@ type AddMessageParams struct {
 	// Body contains the message text.
 	Body string `json:"body"`
 
+	// Subject is the email subject line. Only applicable for email-channel conversations.
+	Subject string `json:"subject,omitempty"`
+
 	// ParticipantID identifies the message sender.
 	ParticipantID string `json:"participant_id"`
 
@@ -93,6 +96,9 @@ type Message struct {
 
 	// Body contains the message text.
 	Body string `json:"body"`
+
+	// Subject is the email subject line. Only applicable for email-channel conversations.
+	Subject string `json:"subject,omitempty"`
 
 	// ParticipantID identifies the message sender.
 	ParticipantID string `json:"participant_id"`


### PR DESCRIPTION
## Summary

- Adds `Subject string` (JSON: `subject,omitempty`) to `AddMessageParams`, placed after `Body`
- Adds `Subject string` (JSON: `subject,omitempty`) to `Message`, placed after `Body`
- The field is used for email-channel conversations and was already supported by the backend but not exposed in the Go client

## Test plan

- [ ] Build passes (`go build ./...`)
- [ ] Verify that setting `Subject` on `AddMessageParams` serialises correctly to JSON
- [ ] Verify that `Subject` is populated on the returned `Message` when the backend echoes it back

🤖 Generated with [Claude Code](https://claude.com/claude-code)