### PR TITLE
Add traffic group exclusion endpoints

### DIFF
--- a/traffic_group_exclusion_create.go
+++ b/traffic_group_exclusion_create.go
@@ -1,0 +1,41 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// CreateTrafficGroupExclusionParams are the parameters to Client.CreateTrafficGroupExclusion.
+type CreateTrafficGroupExclusionParams struct {
+	// GroupID is the unique identifier of the traffic group.
+	GroupID string `json:"-"`
+
+	// TargetType is the type of target to exclude (e.g. "procedure").
+	TargetType string `json:"target_type"`
+
+	// TargetID is the unique identifier of the target to exclude from the group.
+	TargetID string `json:"target_id"`
+}
+
+// CreateTrafficGroupExclusion excludes a target from a traffic group.
+//
+// Note: requires a Management API key.
+func (c *Client) CreateTrafficGroupExclusion(ctx context.Context, p *CreateTrafficGroupExclusionParams) (*TrafficGroupTarget, error) {
+	rsp, err := c.makeRequest(ctx, http.MethodPost, fmt.Sprintf("traffic-groups/%s/exclusions", p.GroupID), p)
+	if err != nil {
+		return nil, err
+	}
+	defer rsp.Body.Close()
+
+	if err := responseError(rsp); err != nil {
+		return nil, err
+	}
+
+	var target TrafficGroupTarget
+	if err := json.NewDecoder(rsp.Body).Decode(&target); err != nil {
+		return nil, err
+	}
+	return &target, nil
+}

--- a/traffic_group_exclusion_delete.go
+++ b/traffic_group_exclusion_delete.go
@@ -1,0 +1,23 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// DeleteTrafficGroupExclusion removes an exclusion from a traffic group.
+//
+// Note: requires a Management API key.
+func (c *Client) DeleteTrafficGroupExclusion(ctx context.Context, trafficGroupID string, targetID string) error {
+	rsp, err := c.makeRequest(ctx, http.MethodDelete, fmt.Sprintf("traffic-groups/%s/exclusions/%s", trafficGroupID, targetID), nil)
+	if err != nil {
+		return err
+	}
+	defer rsp.Body.Close()
+
+	if err := responseError(rsp); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- Adds `CreateTrafficGroupExclusion` method (POST `/traffic-groups/:id/exclusions`) with `CreateTrafficGroupExclusionParams` struct
- Adds `DeleteTrafficGroupExclusion` method (DELETE `/traffic-groups/:id/exclusions/:targetId`)
- Both methods follow the same pattern as the existing `CreateTrafficGroupTarget` / `DeleteTrafficGroupTarget` implementations

## Test plan

- [ ] `go build ./...` passes (verified locally)
- [ ] Manually verify `CreateTrafficGroupExclusion` returns a `*TrafficGroupTarget` on success
- [ ] Manually verify `DeleteTrafficGroupExclusion` returns nil on success

🤖 Generated with [Claude Code](https://claude.com/claude-code)