### PR TITLE
Add back-office task endpoints

### DIFF
--- a/back_office_task.go
+++ b/back_office_task.go
@@ -1,0 +1,41 @@
+package client
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// BackOfficeTaskStatus describes the current state of a back-office task.
+type BackOfficeTaskStatus string
+
+// BackOfficeTask represents a back-office task managed by the AI agent.
+type BackOfficeTask struct {
+	ID             string                             `json:"id"`
+	AgentID        string                             `json:"agent_id"`
+	Status         BackOfficeTaskStatus               `json:"status,omitempty"`
+	Input          json.RawMessage                    `json:"input"`
+	Metadata       map[string]string                  `json:"metadata,omitempty"`
+	Attachments    []BackOfficeTaskResponseAttachment `json:"attachments,omitempty"`
+	Created        time.Time                          `json:"created"`
+	Updated        time.Time                          `json:"updated,omitempty"`
+	Completed      time.Time                          `json:"completed,omitempty"`
+	Failed         time.Time                          `json:"failed,omitempty"`
+	FailureReasons []string                           `json:"failure_reasons,omitempty"`
+	HandedOff      time.Time                          `json:"handed_off,omitempty"`
+	HandOffReason  string                             `json:"hand_off_reason,omitempty"`
+	Result         *BackOfficeTaskResult              `json:"result,omitempty"`
+}
+
+// BackOfficeTaskResponseAttachment is an attachment returned in a BackOfficeTask response.
+type BackOfficeTaskResponseAttachment struct {
+	IdempotencyKey string `json:"idempotency_key"`
+	FileName       string `json:"file_name"`
+	ExternalURL    string `json:"external_url,omitempty"`
+	RawContents    []byte `json:"raw_contents,omitempty"`
+}
+
+// BackOfficeTaskResult holds the output of a completed back-office task.
+type BackOfficeTaskResult struct {
+	ResultType string           `json:"result_type"`
+	Custom     *json.RawMessage `json:"custom,omitempty"`
+}

--- a/back_office_task_create.go
+++ b/back_office_task_create.go
@@ -1,0 +1,64 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+// BackOfficeTaskCreateParams are the parameters to Client.CreateBackOfficeTask.
+type BackOfficeTaskCreateParams struct {
+	// ID is the external identifier for this task.
+	ID string `json:"id"`
+
+	// AgentID identifies the back-office task type to execute.
+	AgentID string `json:"agent_id,omitempty"`
+
+	// Input is the structured input data for the task.
+	Input json.RawMessage `json:"input"`
+
+	// Created optionally sets the task creation timestamp.
+	Created *time.Time `json:"created,omitempty"`
+
+	// Metadata is optional free-form key-value metadata.
+	Metadata map[string]string `json:"metadata,omitempty"`
+
+	// Attachments lists any files to attach to this task.
+	Attachments []BackOfficeTaskAttachment `json:"attachments,omitempty"`
+}
+
+// BackOfficeTaskAttachment is a file attachment for a back-office task creation request.
+type BackOfficeTaskAttachment struct {
+	// FileName is the name of the file.
+	FileName string `json:"file_name"`
+
+	// URL is the publicly accessible URL of the file.
+	// Either URL or Base64Contents must be provided.
+	URL string `json:"url,omitempty"`
+
+	// Base64Contents is the base64-encoded file contents.
+	// Either URL or Base64Contents must be provided.
+	Base64Contents string `json:"base_64_contents,omitempty"`
+}
+
+// CreateBackOfficeTask submits a new back-office task for AI processing.
+//
+// Note: requires a Public API key.
+func (c *Client) CreateBackOfficeTask(ctx context.Context, p BackOfficeTaskCreateParams) (*BackOfficeTask, error) {
+	rsp, err := c.makeRequest(ctx, http.MethodPost, "back-office-tasks", p)
+	if err != nil {
+		return nil, err
+	}
+	defer rsp.Body.Close()
+
+	if err := responseError(rsp); err != nil {
+		return nil, err
+	}
+
+	var task BackOfficeTask
+	if err := json.NewDecoder(rsp.Body).Decode(&task); err != nil {
+		return nil, err
+	}
+	return &task, nil
+}

--- a/back_office_task_read.go
+++ b/back_office_task_read.go
@@ -1,0 +1,29 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// ReadBackOfficeTask retrieves the current state of a back-office task.
+//
+// Note: requires a Public API key.
+func (c *Client) ReadBackOfficeTask(ctx context.Context, taskID string) (*BackOfficeTask, error) {
+	rsp, err := c.makeRequest(ctx, http.MethodGet, fmt.Sprintf("back-office-tasks/%s/read", taskID), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer rsp.Body.Close()
+
+	if err := responseError(rsp); err != nil {
+		return nil, err
+	}
+
+	var task BackOfficeTask
+	if err := json.NewDecoder(rsp.Body).Decode(&task); err != nil {
+		return nil, err
+	}
+	return &task, nil
+}


### PR DESCRIPTION
## Summary

- Adds `BackOfficeTask`, `BackOfficeTaskResult`, `BackOfficeTaskAttachment`, and `BackOfficeTaskResponseAttachment` shared types in `back_office_task.go`
- Implements `CreateBackOfficeTask` (`POST /back-office-tasks`) in `back_office_task_create.go`
- Implements `ReadBackOfficeTask` (`GET /back-office-tasks/:id/read`) in `back_office_task_read.go`

## Test plan

- [ ] `go build ./...` passes (verified locally)
- [ ] Call `CreateBackOfficeTask` with a valid payload and confirm a `BackOfficeTask` is returned
- [ ] Call `ReadBackOfficeTask` with the returned task ID and confirm the task state is returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)