### PR TITLE
Deprecate AddResource method

### DIFF
--- a/conversation_add_resource.go
+++ b/conversation_add_resource.go
@@ -24,6 +24,9 @@ import (
 //
 // Names should be descriptive handles that are the same for all conversations
 // (e.g. "order-details" and "user-profile") not unique identifiers.
+//
+// Deprecated: this endpoint has been removed from the backend. Pass resources
+// via StartConversationParams.Resources or ConversationResumeParams.Resources instead.
 func (c *Client) AddResource(ctx context.Context, conversationID string, name string, resource any) error {
 	rsp, err := c.makeRequest(ctx, http.MethodPut, fmt.Sprintf("conversations/%s/resources/%s", conversationID, name), resource)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Marks `AddResource` as deprecated in its godoc comment using the standard `// Deprecated:` godoc convention
- The PUT `/conversations/:id/resources/:name` backend endpoint has been removed; calling `AddResource` would result in 404 errors at runtime
- Directs callers to pass resources via `StartConversationParams.Resources` or `ConversationResumeParams.Resources` instead
- The method itself is kept in place to avoid a breaking change; removal should go through a separate deprecation cycle

## Test plan

- [x] `go build ./...` passes with no errors
- [x] Deprecation notice follows the standard Go `// Deprecated:` godoc format recognised by `gopls` and `go vet`

🤖 Generated with [Claude Code](https://claude.com/claude-code)