### PR TITLE
Add terminology substitutions CRUD

### DIFF
--- a/terminology_substitution.go
+++ b/terminology_substitution.go
@@ -1,0 +1,36 @@
+package client
+
+import "time"
+
+// TerminologySubstitution configures a word or phrase that the AI agent should
+// avoid, replacing it with an approved alternative.
+type TerminologySubstitution struct {
+	// ID uniquely identifies this terminology substitution.
+	ID string `json:"id"`
+
+	// Blocked is the word or phrase the AI agent must not use.
+	Blocked string `json:"blocked"`
+
+	// BlockedDescription explains why the blocked term should not be used.
+	BlockedDescription string `json:"blocked_description"`
+
+	// Replacement is the approved alternative the AI agent should use instead.
+	Replacement string `json:"replacement"`
+
+	// ResourceTypeID optionally scopes the substitution to a specific resource type.
+	ResourceTypeID string `json:"resource_type_id,omitempty"`
+
+	// ResourceAttributeJSONPath optionally scopes the substitution to a specific
+	// attribute within the resource type.
+	ResourceAttributeJSONPath string `json:"resource_attribute_json_path,omitempty"`
+
+	// ResourceValueToMatch optionally further scopes the substitution to cases where
+	// the resource attribute equals this value.
+	ResourceValueToMatch string `json:"resource_value_to_match,omitempty"`
+
+	// Created is the time at which this substitution was created.
+	Created time.Time `json:"created"`
+
+	// Updated is the time at which this substitution was last updated.
+	Updated time.Time `json:"updated"`
+}

--- a/terminology_substitution_create.go
+++ b/terminology_substitution_create.go
@@ -1,0 +1,38 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+// TerminologySubstitutionCreateParams are the parameters to Client.CreateTerminologySubstitution.
+type TerminologySubstitutionCreateParams struct {
+	Blocked                   string `json:"blocked"`
+	BlockedDescription        string `json:"blocked_description"`
+	Replacement               string `json:"replacement"`
+	ResourceTypeID            string `json:"resource_type_id,omitempty"`
+	ResourceAttributeJSONPath string `json:"resource_attribute_json_path,omitempty"`
+	ResourceValueToMatch      string `json:"resource_value_to_match,omitempty"`
+}
+
+// CreateTerminologySubstitution creates a new terminology substitution.
+//
+// Note: requires a Management API key.
+func (c *Client) CreateTerminologySubstitution(ctx context.Context, p *TerminologySubstitutionCreateParams) (*TerminologySubstitution, error) {
+	rsp, err := c.makeRequest(ctx, http.MethodPost, "terminology-substitutions", p)
+	if err != nil {
+		return nil, err
+	}
+	defer rsp.Body.Close()
+
+	if err := responseError(rsp); err != nil {
+		return nil, err
+	}
+
+	var sub TerminologySubstitution
+	if err := json.NewDecoder(rsp.Body).Decode(&sub); err != nil {
+		return nil, err
+	}
+	return &sub, nil
+}

--- a/terminology_substitution_delete.go
+++ b/terminology_substitution_delete.go
@@ -1,0 +1,23 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// DeleteTerminologySubstitution removes a terminology substitution.
+//
+// Note: requires a Management API key.
+func (c *Client) DeleteTerminologySubstitution(ctx context.Context, id string) error {
+	rsp, err := c.makeRequest(ctx, http.MethodDelete, fmt.Sprintf("terminology-substitutions/%s", id), nil)
+	if err != nil {
+		return err
+	}
+	defer rsp.Body.Close()
+
+	if err := responseError(rsp); err != nil {
+		return err
+	}
+	return nil
+}

--- a/terminology_substitution_list.go
+++ b/terminology_substitution_list.go
@@ -1,0 +1,34 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+// TerminologySubstitutionListResponse is the response from Client.ListTerminologySubstitutions.
+type TerminologySubstitutionListResponse struct {
+	Substitutions []*TerminologySubstitution `json:"substitutions"`
+}
+
+// ListTerminologySubstitutions returns all terminology substitutions configured
+// for your company.
+//
+// Note: requires a Management API key.
+func (c *Client) ListTerminologySubstitutions(ctx context.Context) (*TerminologySubstitutionListResponse, error) {
+	rsp, err := c.makeRequest(ctx, http.MethodGet, "terminology-substitutions", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer rsp.Body.Close()
+
+	if err := responseError(rsp); err != nil {
+		return nil, err
+	}
+
+	var result TerminologySubstitutionListResponse
+	if err := json.NewDecoder(rsp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}

--- a/terminology_substitution_read.go
+++ b/terminology_substitution_read.go
@@ -1,0 +1,29 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// ReadTerminologySubstitution retrieves a single terminology substitution by ID.
+//
+// Note: requires a Management API key.
+func (c *Client) ReadTerminologySubstitution(ctx context.Context, id string) (*TerminologySubstitution, error) {
+	rsp, err := c.makeRequest(ctx, http.MethodGet, fmt.Sprintf("terminology-substitutions/%s", id), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer rsp.Body.Close()
+
+	if err := responseError(rsp); err != nil {
+		return nil, err
+	}
+
+	var sub TerminologySubstitution
+	if err := json.NewDecoder(rsp.Body).Decode(&sub); err != nil {
+		return nil, err
+	}
+	return &sub, nil
+}

--- a/terminology_substitution_update.go
+++ b/terminology_substitution_update.go
@@ -1,0 +1,39 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// TerminologySubstitutionUpdateParams are the parameters to Client.UpdateTerminologySubstitution.
+type TerminologySubstitutionUpdateParams struct {
+	Blocked                   string `json:"blocked"`
+	BlockedDescription        string `json:"blocked_description"`
+	Replacement               string `json:"replacement"`
+	ResourceTypeID            string `json:"resource_type_id,omitempty"`
+	ResourceAttributeJSONPath string `json:"resource_attribute_json_path,omitempty"`
+	ResourceValueToMatch      string `json:"resource_value_to_match,omitempty"`
+}
+
+// UpdateTerminologySubstitution replaces an existing terminology substitution.
+//
+// Note: requires a Management API key.
+func (c *Client) UpdateTerminologySubstitution(ctx context.Context, id string, p *TerminologySubstitutionUpdateParams) (*TerminologySubstitution, error) {
+	rsp, err := c.makeRequest(ctx, http.MethodPut, fmt.Sprintf("terminology-substitutions/%s", id), p)
+	if err != nil {
+		return nil, err
+	}
+	defer rsp.Body.Close()
+
+	if err := responseError(rsp); err != nil {
+		return nil, err
+	}
+
+	var sub TerminologySubstitution
+	if err := json.NewDecoder(rsp.Body).Decode(&sub); err != nil {
+		return nil, err
+	}
+	return &sub, nil
+}


### PR DESCRIPTION
## Summary

- Adds the `TerminologySubstitution` type with all fields (blocked term, description, replacement, optional resource scoping, timestamps)
- Implements `ListTerminologySubstitutions`, `CreateTerminologySubstitution`, `ReadTerminologySubstitution`, `UpdateTerminologySubstitution`, and `DeleteTerminologySubstitution` on `*Client`
- Follows the same file-per-operation pattern as other resources (note, resource_type, traffic_group, etc.)

## Test plan

- [ ] `go build ./...` passes (verified locally)
- [ ] Manually test each endpoint against the backend once deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)