### PR TITLE
Add voice call context endpoint

### DIFF
--- a/voice_call_context.go
+++ b/voice_call_context.go
@@ -1,0 +1,29 @@
+package client
+
+import "time"
+
+// VoiceCallContext contains context information about the most recent voice call
+// for a given phone number.
+type VoiceCallContext struct {
+	// StartedAt is the time the call began.
+	StartedAt time.Time `json:"started_at"`
+
+	// Summary is a short summary of the call (truncated unless IncludeLargeFields is set).
+	Summary string `json:"summary,omitempty"`
+
+	// Transcript is the full formatted conversation transcript.
+	// Only populated when ReadVoiceCallContextParams.IncludeLargeFields is true.
+	Transcript string `json:"transcript,omitempty"`
+
+	// HandoffReason is the reason the call was handed off to a human agent, if at all.
+	HandoffReason string `json:"handoff_reason,omitempty"`
+
+	// LastExecutedProcedure is the name of the last procedure executed during the call.
+	LastExecutedProcedure string `json:"last_executed_procedure,omitempty"`
+
+	// LastExecutedProcedureURL is a link to the procedure in the Gradient Labs UI.
+	LastExecutedProcedureURL string `json:"last_executed_procedure_url,omitempty"`
+
+	// GradientLabsURL is a link to the call conversation in the Gradient Labs UI.
+	GradientLabsURL string `json:"gradient_labs_url,omitempty"`
+}

--- a/voice_call_context_read.go
+++ b/voice_call_context_read.go
@@ -1,0 +1,54 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+)
+
+// ReadVoiceCallContextParams are the parameters to Client.ReadLatestVoiceCallContext.
+type ReadVoiceCallContextParams struct {
+	// LookbackSeconds sets the time window (in seconds) within which to search for
+	// recent call events. Defaults to 60 if not set; minimum 5.
+	LookbackSeconds int
+
+	// IncludeLargeFields includes the full transcript and complete summary in the
+	// response when true. Defaults to false.
+	IncludeLargeFields bool
+}
+
+// ReadLatestVoiceCallContext returns the most recent voice call context for the
+// given phone number.
+//
+// Note: requires a Public API key.
+func (c *Client) ReadLatestVoiceCallContext(ctx context.Context, phoneNumber string, p *ReadVoiceCallContextParams) (*VoiceCallContext, error) {
+	path := fmt.Sprintf("voice/latest-call-context/%s", phoneNumber)
+	if p != nil {
+		sep := "?"
+		if p.LookbackSeconds > 0 {
+			path += sep + "lookback_seconds=" + strconv.Itoa(p.LookbackSeconds)
+			sep = "&"
+		}
+		if p.IncludeLargeFields {
+			path += sep + "include_large_fields=true"
+		}
+	}
+
+	rsp, err := c.makeRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer rsp.Body.Close()
+
+	if err := responseError(rsp); err != nil {
+		return nil, err
+	}
+
+	var result VoiceCallContext
+	if err := json.NewDecoder(rsp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}


### PR DESCRIPTION
## Summary

- Adds `VoiceCallContext` type (`voice_call_context.go`) with fields for call start time, summary, transcript, handoff reason, last executed procedure, and UI links.
- Adds `ReadLatestVoiceCallContext` method (`voice_call_context_read.go`) that calls `GET /voice/latest-call-context/:phoneNumber` with optional `lookback_seconds` and `include_large_fields` query parameters.

## Test plan

- [ ] `go build ./...` passes (verified locally)
- [ ] Confirm `LookbackSeconds=0` omits the query param (only non-zero values are sent)
- [ ] Confirm `IncludeLargeFields=false` omits the query param
- [ ] Confirm both query params are appended correctly when set
- [ ] Integration test against the backend endpoint with a real phone number

🤖 Generated with [Claude Code](https://claude.com/claude-code)