### PR TITLE
Add optional version param to ReadTool

### DIFF
--- a/tool_read.go
+++ b/tool_read.go
@@ -7,11 +7,26 @@ import (
 	"net/http"
 )
 
-// ReadTool retrieves a new tool.
+// ReadToolParams are the optional parameters to Client.ReadTool.
+type ReadToolParams struct {
+	// Version optionally specifies which tool revision to retrieve.
+	// If zero, the latest version is returned.
+	Version int
+}
+
+// ReadTool retrieves a tool.
+//
+// Pass a non-nil p to supply optional parameters such as a specific version.
+// Pass nil (or a zero-value ReadToolParams) to retrieve the latest version.
 //
 // Note: requires a `Management` API key.
-func (c *Client) ReadTool(ctx context.Context, toolID string) (*Tool, error) {
-	rsp, err := c.makeRequest(ctx, http.MethodGet, fmt.Sprintf("tools/%s", toolID), nil)
+func (c *Client) ReadTool(ctx context.Context, toolID string, p *ReadToolParams) (*Tool, error) {
+	path := fmt.Sprintf("tools/%s", toolID)
+	if p != nil && p.Version > 0 {
+		path = fmt.Sprintf("%s?version=%d", path, p.Version)
+	}
+
+	rsp, err := c.makeRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- Adds `ReadToolParams` struct with a `Version int` field to `tool_read.go`.
- Updates `Client.ReadTool` to accept `*ReadToolParams` as a third argument.
- When `p.Version > 0`, appends `?version=<v>` to the `GET /tools/:id` request path, allowing callers to retrieve a specific tool revision.
- Passing `nil` (or a zero-value `ReadToolParams`) preserves existing behaviour and returns the latest version.

## Breaking change

This is a **breaking change** to the `ReadTool` method signature:

```go
// Before
ReadTool(ctx context.Context, toolID string) (*Tool, error)

// After
ReadTool(ctx context.Context, toolID string, p *ReadToolParams) (*Tool, error)
```

Existing callers must pass `nil` as the third argument to get current behaviour:

```go
tool, err := client.ReadTool(ctx, id, nil)
```

## Test plan

- [ ] `go build ./...` passes (verified locally).
- [ ] Call `ReadTool(ctx, id, nil)` — confirm it hits `GET /tools/:id` with no query string.
- [ ] Call `ReadTool(ctx, id, &ReadToolParams{Version: 3})` — confirm it hits `GET /tools/:id?version=3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)