### PR TITLE
[back-office] add procedure_id to back-office task create

### DIFF
--- a/back_office_task_create.go
+++ b/back_office_task_create.go
@@ -12,8 +12,11 @@ type BackOfficeTaskCreateParams struct {
 	// ID is the external identifier for this task.
 	ID string `json:"id"`
 
-	// AgentID identifies the back-office task type to execute.
+	// AgentID is the agent (agent group) that runs this task.
 	AgentID string `json:"agent_id,omitempty"`
+
+	// ProcedureID is the procedure within the agent to start the task from.
+	ProcedureID string `json:"procedure_id"`
 
 	// Input is the structured input data for the task.
 	Input json.RawMessage `json:"input"`


### PR DESCRIPTION
Adds a procedure_id (proc_) field to the POST /back-office-tasks request so callers name the procedure within the agent (agent_) to start the task from. The ProcedureID field is added to BackOfficeTaskCreateParams.