### PR TITLE
[public-api] add customer support platform identifiers to StartConversation

### DIFF
--- a/conversation_start.go
+++ b/conversation_start.go
@@ -21,6 +21,11 @@ type StartConversationParams struct {
 	// context of conversations the agent has had with this customer.
 	CustomerID string `json:"customer_id"`
 
+	// CustomerSupportPlatformIdentifiers optionally links the customer to
+	// their record(s) in third-party support platforms (e.g. Intercom,
+	// Zendesk), alongside CustomerID.
+	CustomerSupportPlatformIdentifiers []*CustomerSupportPlatformIdentifier `json:"customer_support_platform_identifiers,omitempty"`
+
 	// AssigneeID optionally identifies who the conversation is assigned to.
 	AssigneeID string `json:"assignee_id,omitempty"`
 

--- a/customer_support_platform_identifier.go
+++ b/customer_support_platform_identifier.go
@@ -1,0 +1,48 @@
+package client
+
+// CustomerSupportPlatformIdentifierType identifies the kind of record an
+// identifier points to, for support platforms that have more than one kind
+// of user identifier.
+type CustomerSupportPlatformIdentifierType string
+
+const (
+	// CustomerSupportPlatformIdentifierTypeIntercomLead indicates the
+	// identifier is for an Intercom lead.
+	CustomerSupportPlatformIdentifierTypeIntercomLead CustomerSupportPlatformIdentifierType = "intercom_lead"
+
+	// CustomerSupportPlatformIdentifierTypeIntercomUser indicates the
+	// identifier is for an Intercom user.
+	CustomerSupportPlatformIdentifierTypeIntercomUser CustomerSupportPlatformIdentifierType = "intercom_user"
+
+	// CustomerSupportPlatformIdentifierTypeZendeskConversationUser indicates
+	// the identifier is for a Zendesk conversation (end) user.
+	CustomerSupportPlatformIdentifierTypeZendeskConversationUser CustomerSupportPlatformIdentifierType = "zendesk_conversation_user"
+
+	// CustomerSupportPlatformIdentifierTypeZendeskSupportUser indicates the
+	// identifier is for a Zendesk support user.
+	CustomerSupportPlatformIdentifierTypeZendeskSupportUser CustomerSupportPlatformIdentifierType = "zendesk_support_user"
+
+	// CustomerSupportPlatformIdentifierTypeSalesforceContactID indicates the
+	// identifier is a Salesforce contact ID.
+	CustomerSupportPlatformIdentifierTypeSalesforceContactID CustomerSupportPlatformIdentifierType = "salesforce_contact_id"
+
+	// CustomerSupportPlatformIdentifierTypeSalesforceAccountID indicates the
+	// identifier is a Salesforce account ID.
+	CustomerSupportPlatformIdentifierTypeSalesforceAccountID CustomerSupportPlatformIdentifierType = "salesforce_account_id"
+)
+
+// CustomerSupportPlatformIdentifier links the customer being created to their
+// record in a third-party support platform, alongside CustomerID.
+type CustomerSupportPlatformIdentifier struct {
+	// SupportPlatform is the support platform this identifier belongs to.
+	SupportPlatform SupportPlatform `json:"support_platform"`
+
+	// Type identifies the kind of identifier this is. Only required for
+	// platforms that have more than one kind of identifier: intercom,
+	// zendesk, and salesforce. Leave this empty for freshchat and freshdesk,
+	// which don't have subtypes.
+	Type CustomerSupportPlatformIdentifierType `json:"type,omitempty"`
+
+	// Value is the external ID of the customer in the support platform.
+	Value string `json:"value"`
+}


### PR DESCRIPTION
## Summary
- Adds an optional `CustomerSupportPlatformIdentifiers` field to `StartConversationParams`, letting callers link the customer being created to their record(s) in third-party support platforms (Intercom, Zendesk, Salesforce, Freshchat, Freshdesk), alongside `CustomerID`.
- `Type` is only required/validated for `intercom`, `zendesk`, and `salesforce`; leave it empty for `freshchat`/`freshdesk`.

Matches the corresponding backend change in wearegradient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)