### PR TITLE
[api] add delete conversation & back-office task endpoints

### DIFF
--- a/back_office_task_delete.go
+++ b/back_office_task_delete.go
@@ -1,0 +1,24 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// DeleteBackOfficeTask deletes a back-office task by its ID. The task must not
+// be in an in-progress state, and on-demand deletion must be enabled.
+//
+// Note: requires a `Management` API key.
+func (c *Client) DeleteBackOfficeTask(ctx context.Context, taskID string) error {
+	rsp, err := c.makeRequest(ctx, http.MethodDelete, fmt.Sprintf("back-office-tasks/%s", taskID), nil)
+	if err != nil {
+		return err
+	}
+	defer rsp.Body.Close()
+
+	if err := responseError(rsp); err != nil {
+		return err
+	}
+	return nil
+}

--- a/conversation_delete.go
+++ b/conversation_delete.go
@@ -1,0 +1,24 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// DeleteConversation deletes a conversation by its ID. The conversation must
+// not be in an active state, and on-demand deletion must be enabled.
+//
+// Note: requires a `Management` API key.
+func (c *Client) DeleteConversation(ctx context.Context, conversationID string) error {
+	rsp, err := c.makeRequest(ctx, http.MethodDelete, fmt.Sprintf("conversations/%s", conversationID), nil)
+	if err != nil {
+		return err
+	}
+	defer rsp.Body.Close()
+
+	if err := responseError(rsp); err != nil {
+		return err
+	}
+	return nil
+}

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package client
 
-const version = "0.3.0"
+const version = "0.3.1"


### PR DESCRIPTION
Adds two new public API DELETE endpoints to the Go SDK, matching the OpenAPI spec and docs:

- `DeleteConversation(ctx, conversationID) error` → `DELETE /conversations/{id}`
- `DeleteBackOfficeTask(ctx, taskID) error` → `DELETE /back-office-tasks/{id}`

Both mirror the existing `DeleteArticle` plumbing (Management-role, 202, no body). Bumped version 0.3.0 → 0.3.1.

Verified: `go build ./... && go vet ./... && go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
