### PR TITLE
Add reason_code to Finish Conversation

### DIFF
--- a/conversation_finish.go
+++ b/conversation_finish.go
@@ -14,6 +14,10 @@ type FinishParams struct {
 
 	// Reason optionally allows you to describe why this conversation is finishing.
 	Reason string `json:"reason,omitempty"`
+
+	// ReasonCode optionally categorises why this conversation is finishing.
+	// Valid values are "customer-ended-chat" and "customer-unresponsive".
+	ReasonCode string `json:"reason_code,omitempty"`
 }
 
 // FinishConversation finishes a conversation.

--- a/examples/conversation/main.go
+++ b/examples/conversation/main.go
@@ -89,7 +89,9 @@ func run(client *glabs.Client) error {
 		return err
 	}
 
-	if err := client.FinishConversation(ctx, conv.ID, glabs.FinishParams{}); err != nil {
+	if err := client.FinishConversation(ctx, conv.ID, glabs.FinishParams{
+		ReasonCode: "customer-ended-chat",
+	}); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
The public API `PUT /conversations/{id}/finish` endpoint now accepts an optional `reason_code` request field alongside the existing free-text `reason` and optional `timestamp`. This adds an optional `ReasonCode string` field (json tag `reason_code,omitempty`) to `FinishParams` so callers can categorise why a conversation is finishing (valid values: `customer-ended-chat`, `customer-unresponsive`). The field is optional and typed as a plain string, mirroring how the SDK already models `reason_code` on the hand-off and finished webhook events, so existing finish calls compile and behave unchanged.

Mirrors platform change gradientlabs-ai/wearegradient#30159 and docs gradientlabs-ai/docs#236.

🤖 Generated with [Claude Code](https://claude.com/claude-code)